### PR TITLE
Migration to C++17

### DIFF
--- a/lib/include/sel/visitors.hpp
+++ b/lib/include/sel/visitors.hpp
@@ -80,7 +80,7 @@ namespace sel {
   public:
     using _VisRepr<typename L::cdr>::visit;
     void visit(_b const& it) override {
-      this->visitCommon(it, typename std::conditional<!_b::args, std::true_type, std::false_type>::type{});
+      this->visitCommon((typename std::conditional<!_b::args, Val, Segment>::type&)it, it.type(), _b::the::Base::Next::name, _b::args, _b::the::args);
     }
   };
 
@@ -90,16 +90,17 @@ namespace sel {
     struct ReprField {
       char const* name;
       enum { DBL, STR, VAL } const data_ty;
-      union { double const dbl; std::string const* str; Val const* val; } const data;
+      union { double const dbl; std::string const* str; Val const* val; } const;
+      ReprField(char const* name, double dbl): name(name), data_ty(ReprField::DBL), dbl(dbl) { }
+      ReprField(char const* name, std::string const* str): name(name), data_ty(ReprField::STR), str(str) { }
+      ReprField(char const* name, Val const* val): name(name), data_ty(ReprField::VAL), val(val) { }
     };
     _VisRepr(std::ostream& res, _ReprCx cx): res(res), cx(cx) { }
     std::ostream& res;
     _ReprCx cx;
     void reprHelper(Type const& type, char const* name, std::vector<ReprField> const fields);
-    template <typename T>
-    void visitCommon(T const&, std::false_type is_head);
-    template <typename T>
-    void visitCommon(T const&, std::true_type is_head);
+    void visitCommon(Segment const& it, Type const&, char const* name, unsigned args, unsigned max_args);
+    void visitCommon(Val const& it, Type const&, char const* name, unsigned args, unsigned max_args);
   };
 
   class VisRepr : public _VisRepr<bins_ll::bins_all> {

--- a/lib/src/builtins.cpp
+++ b/lib/src/builtins.cpp
@@ -85,8 +85,8 @@ namespace sel {
       TRACE(copyBody, a::the::Base::Next::name);
       return new _bin_be<NextT, ll::cons<to, ll::cons<from, ll::cons<from_again, from_more>>>>(
         this->app,
-        (a::Base*)base->copy(),
-        (a::Arg*)arg->copy()
+        (a::Base*)_base->copy(),
+        (a::Arg*)_arg->copy()
       ); // copyBody
     }
     template <typename NextT, typename to, typename from, typename from_again, typename from_more>
@@ -100,8 +100,8 @@ namespace sel {
       TRACE(copyTail1, a::the::Base::Next::name);
       return new typename a::Base::Next(
         this->app,
-        (typename a::Base*)base->copy(),
-        (typename a::Arg*)arg->copy()
+        (typename a::Base*)_base->copy(),
+        (typename a::Arg*)_arg->copy()
       ); // copyTail1
     }
     template <typename NextT, typename last_to, typename last_from>
@@ -110,8 +110,8 @@ namespace sel {
       TRACE(copyTail2, a::the::Base::Next::name);
       return new typename a::Base::Next(
         this->app,
-        (typename a::Base*)base->copy(),
-        (typename a::Arg*)arg->copy()
+        (typename a::Base*)_base->copy(),
+        (typename a::Arg*)_arg->copy()
       ); // copyTail2
     }
     template <typename NextT, typename last_to, typename last_from>
@@ -133,10 +133,10 @@ namespace sel {
   } // namespace bins_helpers
 
 #define _depth(__depth) _depth_ ## __depth
-#define _depth_0 arg
-#define _depth_1 base->_depth_0
-#define _depth_2 base->_depth_1
-#define _depth_3 base->_depth_2
+#define _depth_0 _arg
+#define _depth_1 _base->_depth_0
+#define _depth_2 _base->_depth_1
+#define _depth_3 _base->_depth_2
 
 #define _bind_some(__count) _bind_some_ ## __count
 #define _bind_some_1(a)          _bind_one(a, 0)
@@ -154,7 +154,7 @@ namespace sel {
   namespace bins {
 
     double abs_::value() {
-      return std::abs(arg->value());
+      return std::abs(_arg->value());
     }
 
     double add_::value() {
@@ -164,7 +164,7 @@ namespace sel {
 
     std::ostream& bin_::stream(std::ostream& out) {
       read = true;
-      uint64_t a = arg->value();
+      uint64_t a = _arg->value();
       char b[64+1]; b[64] = '\0';
       char* head = b+64;
       do { *--head = '0' + (a & 1); } while (a>>= 1);
@@ -235,9 +235,9 @@ namespace sel {
       return s.end() && buff.length() <= off;
     }
 
-    std::ostream& chr_::stream(std::ostream& out) { read = true; return out << codepoint(arg->value()); }
+    std::ostream& chr_::stream(std::ostream& out) { read = true; return out << codepoint(_arg->value()); }
     bool chr_::end() { return read; }
-    std::ostream& chr_::entire(std::ostream& out) { read = true; return out << codepoint(arg->value()); }
+    std::ostream& chr_::entire(std::ostream& out) { read = true; return out << codepoint(_arg->value()); }
 
     Val* codepoints_::operator*() {
       bind_args(s);
@@ -454,9 +454,9 @@ namespace sel {
       return *l;
     }
 
-    std::ostream& hex_::stream(std::ostream& out) { read = true; return out << std::hex << size_t(arg->value()); }
+    std::ostream& hex_::stream(std::ostream& out) { read = true; return out << std::hex << size_t(_arg->value()); }
     bool hex_::end() { return read; }
-    std::ostream& hex_::entire(std::ostream& out) { read = true; return out << std::hex << size_t(arg->value()); }
+    std::ostream& hex_::entire(std::ostream& out) { read = true; return out << std::hex << size_t(_arg->value()); }
 
     Val* flip_::impl(LastArg& a) {
       bind_args(fun, b);
@@ -637,13 +637,13 @@ namespace sel {
       return M_PI;
     }
 
-    std::ostream& oct_::stream(std::ostream& out) { read = true; return out << std::oct << size_t(arg->value()); }
+    std::ostream& oct_::stream(std::ostream& out) { read = true; return out << std::oct << size_t(_arg->value()); }
     bool oct_::end() { return read; }
-    std::ostream& oct_::entire(std::ostream& out) { read = true; return out << std::oct << size_t(arg->value()); }
+    std::ostream& oct_::entire(std::ostream& out) { read = true; return out << std::oct << size_t(_arg->value()); }
 
     double ord_::value() {
       codepoint c;
-      Str_istream(arg) >> c;
+      Str_istream(_arg) >> c;
       return c.u;
     }
 
@@ -662,7 +662,7 @@ namespace sel {
       return s.entire(px.entire(out));
     }
 
-    Val* repeat_::operator*() { return arg->copy(); }
+    Val* repeat_::operator*() { return _arg->copy(); }
     Lst& repeat_::operator++() { return *this; }
     bool repeat_::end() { return false; }
 
@@ -701,7 +701,7 @@ namespace sel {
       return l.end();
     }
 
-    Val* singleton_::operator*() { return arg; }
+    Val* singleton_::operator*() { return _arg; }
     Lst& singleton_::operator++() { done = true; return *this; }
     bool singleton_::end() { return done; }
 
@@ -870,9 +870,9 @@ namespace sel {
       return r;
     }
 
-    std::ostream& tostr_::stream(std::ostream& out) { read = true; return out << arg->value(); }
+    std::ostream& tostr_::stream(std::ostream& out) { read = true; return out << _arg->value(); }
     bool tostr_::end() { return read; }
-    std::ostream& tostr_::entire(std::ostream& out) { read = true; return out << arg->value(); }
+    std::ostream& tostr_::entire(std::ostream& out) { read = true; return out << _arg->value(); }
 
     Val* tuple_::operator*() {
       bind_args(a, b);

--- a/lib/src/visitors/repr.cpp
+++ b/lib/src/visitors/repr.cpp
@@ -2,10 +2,6 @@
 
 namespace sel {
 
-#define fi_dbl(__name, __dbl) {.name=__name, .data_ty=ReprField::DBL, .data={.dbl=__dbl}}
-#define fi_str(__name, __str) {.name=__name, .data_ty=ReprField::STR, .data={.str=__str}}
-#define fi_val(__name, __val) {.name=__name, .data_ty=ReprField::VAL, .data={.val=__val}}
-
   void _VisRepr<bins_ll::nil>::reprHelper(Type const& type, char const* name, std::vector<ReprField> const fields) {
     bool isln = 1 < fields.size() && !cx.single_line;
 
@@ -34,18 +30,18 @@ namespace sel {
 
       switch (it.data_ty) {
         case ReprField::DBL:
-          res << " " << it.data.dbl;
+          res << " " << it.dbl;
           break;
 
         case ReprField::STR:
-          res << " " << quoted(*it.data.str);
+          res << " " << quoted(*it.str);
           break;
 
         case ReprField::VAL:
-          if (it.data.val) {
+          if (it.val) {
             bool was_top = cx.top_level;
             cx.top_level = false;
-            this->operator()(*it.data.val);
+            this->operator()(*it.val);
             cx.top_level = was_top;
           } else res << " -nil-";
           break;
@@ -62,13 +58,13 @@ namespace sel {
 
   void VisRepr::visitNumLiteral(Type const& type, double n) {
     reprHelper(type, "NumLiteral", {
-      fi_dbl("n", n),
+      ReprField("n", n),
     });
   }
 
   void VisRepr::visitStrLiteral(Type const& type, std::string const& s) {
     reprHelper(type, "StrLiteral", {
-      fi_str("s", &s),
+      ReprField("s", &s),
     });
   }
 
@@ -79,7 +75,7 @@ namespace sel {
     a.reserve(c);
     for (size_t k = 0; k < c; k++) {
       std::sprintf(b[k], "v[%zu]", k);
-      a.push_back(fi_val(b[k], v[k]));
+      a.push_back(ReprField(b[k], v[k]));
     }
     reprHelper(type, "LstLiteral", a);
   }
@@ -91,7 +87,7 @@ namespace sel {
     a.reserve(c);
     for (size_t k = 0; k < c; k++) {
       std::sprintf(b[k], "f[%zu]", k);
-      a.push_back(fi_val(b[k], (Val*)f[k]));
+      a.push_back(ReprField(b[k], (Val*)f[k]));
     }
     reprHelper(type, "FunChain", a);
   }
@@ -103,14 +99,14 @@ namespace sel {
     a.reserve(c);
     for (size_t k = 0; k < c; k++) {
       std::sprintf(b[k], "v[%zu]", k);
-      a.push_back(fi_str(b[k], &vs[k]));
+      a.push_back(ReprField(b[k], &vs[k]));
     }
     reprHelper(type, "StrChunks", a);
   }
 
   void VisRepr::visitLstMapCoerse(Type const& type, Lst const& l) {
     reprHelper(type, "LstMapCoerse", {
-      fi_val("l", &l),
+      ReprField("l", &l),
     });
   }
 
@@ -118,25 +114,23 @@ namespace sel {
     reprHelper(type, "Input", {});
   }
 
-  template <typename T>
-  void _VisRepr<bins_ll::nil>::visitCommon(T const& it, std::false_type is_head) {
+  void _VisRepr<bins_ll::nil>::visitCommon(Segment const& it, Type const& type, char const* name, unsigned args, unsigned max_args) {
     std::string normalized // capitalizes first letter and append arity
-      = (char)(T::the::Base::Next::name[0]+('A'-'a'))
-      + ((T::the::Base::Next::name+1)
-      + std::to_string(T::the::args-T::args));
-    reprHelper(it.type(), normalized.c_str(), {
-      fi_val("base", it.base),
-      fi_val("arg", it.arg),
+      = (char)(name[0]+('A'-'a'))
+      + ((name+1)
+      + std::to_string(max_args-args));
+    reprHelper(type, normalized.c_str(), {
+      ReprField("base", &it.base()),
+      ReprField("arg", &it.arg()),
     });
   }
 
-  template <typename T>
-  void _VisRepr<bins_ll::nil>::visitCommon(T const& it, std::true_type is_head) {
+  void _VisRepr<bins_ll::nil>::visitCommon(Val const& it, Type const& type, char const* name, unsigned args, unsigned max_args) {
     std::string normalized // capitalizes first letter and append arity
-      = (char)(T::the::Base::Next::name[0]+('A'-'a'))
-      + ((T::the::Base::Next::name+1)
-      + std::to_string(T::the::args-T::args));
-    reprHelper(it.type(), normalized.c_str(), {});
+      = (char)(name[0]+('A'-'a'))
+      + ((name+1)
+      + std::to_string(max_args-args));
+    reprHelper(type, normalized.c_str(), {});
   }
 
 } // namespace sel

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('sel', 'cpp',
-  default_options : ['cpp_std=c++11'],
+  default_options : ['cpp_std=c++17'],
   version : '0.1.8',
   license : 'MIT',
 )

--- a/poc.cpp
+++ b/poc.cpp
@@ -1,0 +1,112 @@
+#include <iostream>
+// #include <typeinfo>
+
+
+struct Base { };
+
+struct a : Base { constexpr static char const* name = "a"; };
+struct b : Base { constexpr static char const* name = "b"; };
+struct c : Base { constexpr static char const* name = "c"; };
+struct d : Base { constexpr static char const* name = "d"; };
+
+template <typename A, typename D>
+struct cons {
+  typedef A car;
+  typedef D cdr;
+};
+struct nil;
+
+typedef cons<a, cons<b, cons<c, cons<d, nil>>>> all;
+
+
+template <typename ...T> struct pack;
+
+template <typename L, typename ...Pack>
+struct packer {
+  typedef typename packer<typename L::cdr, Pack..., typename L::car>::packed packed;
+};
+template <typename ...Pack>
+struct packer<nil, Pack...> {
+  typedef pack<Pack...> packed;
+};
+
+typedef packer<all>::packed all_pack;
+
+
+// class VisitorExplicit {
+// public:
+//   virtual ~VisitorExplicit() { }
+//   virtual void visit(a const&) { }
+//   virtual void visit(b const&) { }
+//   virtual void visit(c const&) { }
+//   virtual void visit(d const&) { }
+// };
+
+
+// template <typename L>
+// class _VisitorInherit : _VisitorInherit<typename L::cdr> {
+// public:
+//   using _VisitorInherit<typename L::cdr>::visit;
+//   void visit(typename L::car const&);
+// };
+// template <>
+// class _VisitorInherit<nil> {
+// public:
+//   void visit();
+// };
+// class VisitorInherit : _VisitorInherit<all> { };
+
+
+template <typename O>
+class VisitorOne {
+public:
+  virtual ~VisitorOne() { }
+  virtual void visit(O const&) { std::cout << "base for " << O::name << std::endl; }
+};
+template <typename PackItself> class _VisitorPackAll;
+template <typename ...Pack>
+class _VisitorPackAll<pack<Pack...>> : public VisitorOne<Pack>... { };
+
+class Visitor : public _VisitorPackAll<all_pack> { };
+
+
+class _VisSomeRoot {
+protected:
+  void visitCommon() { std::cout << "override for "; }
+};
+
+template <typename O>
+class _VisSomeOne : public VisitorOne<O>, protected _VisSomeRoot {
+public:
+  void visit(O const&) override { visitCommon(); std::cout << O::name << std::endl; }
+};
+
+template <typename PackItself> class _VisSomeAll;
+template <typename ...Pack>
+class _VisSomeAll<pack<Pack...>> : public _VisSomeOne<Pack>... {
+public:
+  using VisitorOne<Pack>::visit...; // C++17
+};
+
+class VisSome : public _VisSomeAll<all_pack> { };
+
+
+using namespace std;
+
+int main() {
+  // cout << "VisitorExplicit: " << typeid(VisitorExplicit).name() << endl;
+  // cout << endl;
+
+  // cout << "VisitorInherit: " << typeid(VisitorInherit).name() << endl;
+  // cout << "_VisitorInherit<all>: " << typeid(_VisitorInherit<all>).name() << endl;
+  // cout << endl;
+
+  // cout << "VisitorPack: " << typeid(VisitorPack).name() << endl;
+  // cout << "_VisitorPackAll<a, b, c, d>: " << typeid(_VisitorPackAll<all_pack>).name() << endl;
+  // cout << endl;
+
+  VisSome v;
+  v.visit(a());
+
+  return 0;
+}


### PR DESCRIPTION
Motivation:
- pack expansion in `using` declaration makes it possible to reformulate the visitor pattern from O(n^2) to O(n) (see [this POC](https://github.com/naclsn/sel/blob/be3d848323d5f504428d55351ecb2ae00d8ce3e0/poc.cpp))
- LLVM moving to C++17 (1 year ago, with for plan version 16): the used version would be bumped to 14 on branch codegen
- gcc default -std virtually everywhere
- C++17 is 5 years old by now... there were no good reason to stick with C++11 to begin with

I want to look in more detail at what it brings/changes. Will experiment with all this. (Have not been able to build at all yet, g++ just hangs.)